### PR TITLE
Expose node context api

### DIFF
--- a/packages/core/src/index.tsx
+++ b/packages/core/src/index.tsx
@@ -4,3 +4,6 @@ export * from "./hooks";
 export * from "./interfaces";
 export * from "./nodes";
 export * from "./render";
+
+// We expose this methods for candu's internal usage. Use at your own risksi
+export { useInternalEditor } from "./editor/useInternalEditor";

--- a/packages/core/src/nodes/index.ts
+++ b/packages/core/src/nodes/index.ts
@@ -1,1 +1,2 @@
 export * from "./Canvas";
+export * from "./useNodeContext";

--- a/packages/core/src/nodes/useInternalNode.ts
+++ b/packages/core/src/nodes/useInternalNode.ts
@@ -1,7 +1,9 @@
 import { useContext, useMemo } from "react";
-import { NodeContext, NodeProvider } from "./NodeContext";
+import { NodeProvider } from "./NodeContext";
 import { Node } from "../interfaces";
 import { useInternalEditor } from "../editor/useInternalEditor";
+
+import { useNodeContext } from "./useNodeContext";
 
 type internalActions = NodeProvider & {
   inNodeContext: boolean;
@@ -20,7 +22,7 @@ export function useInternalNode<S = null>(
 export function useInternalNode<S = null>(
   collect?: (node: Node) => S
 ): useInternalNode<S> {
-  const context = useContext(NodeContext);
+  const context = useNodeContext();
   const { id, related, connectors } = context;
 
   const { actions: EditorActions, query, ...collected } = useInternalEditor(

--- a/packages/core/src/nodes/useNodeContext.ts
+++ b/packages/core/src/nodes/useNodeContext.ts
@@ -1,0 +1,5 @@
+import { useContext } from "react";
+
+import { NodeContext } from "./NodeContext";
+
+export const useNodeContext = () => useContext(NodeContext);


### PR DESCRIPTION
# New
<!-- Provide a description of the changes you’ve made in this pr -->
* Expose `useNodeContext` and `useInternalNode`.

This is only for internal usage at Candu. We want to do this because we want to split `useNode` and `useNodeContext` into two separate, more comparable interfaces.

# Testing
<!-- Please select all the testing methods that apply to this pr -->

- [ ] Unit
- [ ] Integration
- [ ] Localhost

# Screenshots
<!-- If you have made client facing changes please provide screenshots -->