### PR TITLE
Adds check if resolver has isCanvas set

### DIFF
--- a/packages/core/src/utils/createNode.ts
+++ b/packages/core/src/utils/createNode.ts
@@ -54,6 +54,10 @@ export function createNode(
         node.data.displayName = actualType.craft.name;
       }
 
+      if (actualType.craft.isCanvas) {
+        node.data.isCanvas = true;
+      }
+
       if (actualType.craft.rules) {
         Object.keys(actualType.craft.rules).forEach((key) => {
           if (["canDrag", "canMoveIn", "canMoveOut"].includes(key)) {


### PR DESCRIPTION
# New
<!-- Provide a description of the changes you’ve made in this pr -->
- If resolver has isCanvas set to true in craft object, craft will correctly use that resolver as canvas
