### PR TITLE
fix: use Subscriber to handle onStateChange

### DIFF
--- a/packages/core/src/editor/Editor.tsx
+++ b/packages/core/src/editor/Editor.tsx
@@ -35,13 +35,16 @@ export const Editor: React.FC<Partial<Options>> = ({
       });
   }, [context, options]);
 
-  const json = context && context.query.serialize();
-  const { onStateChange } = options;
-  // because `useEffect` doesnt allow for deep comparison, we use this trick.
-  // TODO: improve to actually use a deep comparison.
   useEffect(() => {
-    onStateChange && json && onStateChange(JSON.parse(json));
-  }, [onStateChange, json]);
+    context.subscribe(
+      (_) => ({
+        json: context.query.serialize(),
+      }),
+      ({ json }) => {
+        context.query.getOptions().onStateChange(JSON.parse(json));
+      }
+    );
+  }, [context]);
 
   return context ? (
     <EditorContext.Provider value={context}>

--- a/packages/core/src/editor/tests/Editor.test.tsx
+++ b/packages/core/src/editor/tests/Editor.test.tsx
@@ -35,7 +35,6 @@ describe("<Editor />", () => {
   it("should render the EditorContext.Provider", () => {
     expect(component.find(EditorContext.Provider)).toHaveLength(1);
   });
-  it("should have called serialize", () => {
-    expect(query.serialize).toHaveBeenCalled();
-  });
+
+  // TODO: use react-testing-library to test hook-related code
 });


### PR DESCRIPTION
# New

This PR fixes the `onStateChange` bug in `<Editor />` where it's called before any changes actually takes place.

This fix uses the Craft.js Subscriber to collect the editor JSON and passes it to the onStateChange callback when there is a change.


# Testing
- [x] Localhost