### PR TITLE
feat: Implement History API

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,8 @@
       "<rootDir>/packages/core/"
     ],
     "testMatch": [
-      "<rootDir>/packages/core/src/**/?(*.)(spec|test).ts(x|)"
+      "<rootDir>/packages/core/src/**/?(*.)(spec|test).ts(x|)",
+      "<rootDir>/packages/utils/src/**/?(*.)(spec|test).ts(x|)"
     ],
     "transform": {
       "^.+\\.(ts|tsx)$": "ts-jest"

--- a/package.json
+++ b/package.json
@@ -90,8 +90,7 @@
       "<rootDir>/packages/core/"
     ],
     "testMatch": [
-      "<rootDir>/packages/core/src/**/?(*.)(spec|test).ts(x|)",
-      "<rootDir>/packages/utils/src/**/?(*.)(spec|test).ts(x|)"
+      "<rootDir>/packages/**/?(*.)(spec|test).ts(x|)"
     ],
     "transform": {
       "^.+\\.(ts|tsx)$": "ts-jest"

--- a/packages/core/src/editor/store.tsx
+++ b/packages/core/src/editor/store.tsx
@@ -8,7 +8,12 @@ export const useEditorStore = (options): EditorStore => {
   return useMethods(
     {
       methods: Actions as any,
-      actionsToIgnore: ["setDOM", "setNodeEvent", "setOptions", "setIndicator"],
+      ignoreHistoryForActions: [
+        "setDOM",
+        "setNodeEvent",
+        "setOptions",
+        "setIndicator",
+      ],
     },
     {
       nodes: {},

--- a/packages/core/src/editor/store.tsx
+++ b/packages/core/src/editor/store.tsx
@@ -2,19 +2,24 @@ import { useMethods, SubscriberAndCallbacksFor } from "@candulabs/craft-utils";
 import { Actions } from "./actions";
 import { QueryMethods } from "./query";
 
-export type EditorStore = SubscriberAndCallbacksFor<typeof Actions>;
+export const ActionMethodsWithConfig = {
+  methods: Actions,
+  ignoreHistoryForActions: [
+    "setDOM",
+    "setNodeEvent",
+    "setOptions",
+    "setIndicator",
+  ] as const,
+};
+
+export type EditorStore = SubscriberAndCallbacksFor<
+  typeof ActionMethodsWithConfig,
+  typeof QueryMethods
+>;
 
 export const useEditorStore = (options): EditorStore => {
   return useMethods(
-    {
-      methods: Actions as any,
-      ignoreHistoryForActions: [
-        "setDOM",
-        "setNodeEvent",
-        "setOptions",
-        "setIndicator",
-      ],
-    },
+    ActionMethodsWithConfig,
     {
       nodes: {},
       events: {
@@ -26,5 +31,5 @@ export const useEditorStore = (options): EditorStore => {
       options,
     },
     QueryMethods
-  );
+  ) as EditorStore;
 };

--- a/packages/core/src/editor/store.tsx
+++ b/packages/core/src/editor/store.tsx
@@ -8,7 +8,7 @@ export const useEditorStore = (options): EditorStore => {
   return useMethods(
     {
       methods: Actions as any,
-      ignoreHistory: ["setDOM", "setNodeEvent", "setOptions", "setIndicator"],
+      actionsToIgnore: ["setDOM", "setNodeEvent", "setOptions", "setIndicator"],
     },
     {
       nodes: {},

--- a/packages/core/src/editor/store.tsx
+++ b/packages/core/src/editor/store.tsx
@@ -6,7 +6,10 @@ export type EditorStore = SubscriberAndCallbacksFor<typeof Actions>;
 
 export const useEditorStore = (options): EditorStore => {
   return useMethods(
-    Actions,
+    {
+      methods: Actions as any,
+      ignoreHistory: ["setDOM", "setNodeEvent", "setOptions", "setIndicator"],
+    },
     {
       nodes: {},
       events: {

--- a/packages/core/src/editor/useInternalEditor.ts
+++ b/packages/core/src/editor/useInternalEditor.ts
@@ -2,7 +2,7 @@ import { useContext, useMemo } from "react";
 import { EditorState } from "../interfaces";
 import { QueryMethods } from "./query";
 import { useCollector, QueryCallbacksFor } from "@candulabs/craft-utils";
-import { Actions } from "./actions";
+import { ActionMethodsWithConfig } from "./store";
 import { useEventHandler } from "../events/EventContext";
 import { EditorContext } from "./EditorContext";
 import { EventConnectors } from "../events/EventHandlers";
@@ -13,8 +13,8 @@ export type EditorCollector<C> = (
 ) => C;
 
 export type useInternalEditor<C = null> = (C extends null
-  ? useCollector<typeof Actions, typeof QueryMethods>
-  : useCollector<typeof Actions, typeof QueryMethods, C>) & {
+  ? useCollector<typeof ActionMethodsWithConfig, typeof QueryMethods>
+  : useCollector<typeof ActionMethodsWithConfig, typeof QueryMethods, C>) & {
   inContext: boolean;
   store: EditorContext;
   connectors: EventConnectors;

--- a/packages/core/src/hooks/tests/useEditor.test.tsx
+++ b/packages/core/src/hooks/tests/useEditor.test.tsx
@@ -7,7 +7,15 @@ jest.mock("../../editor/useInternalEditor");
 const internalEditorMock = useInternalEditor as jest.Mock<any>;
 
 describe("useEditor", () => {
-  const otherActions = { one: "one" };
+  const otherActions = {
+    one: "one",
+    runWithoutHistory: {
+      replaceNodes: "replaceNodes",
+      reset: "reset",
+      replaceEvents: "replaceEvents",
+      actions: "actions",
+    },
+  };
   const actions = {
     setDOM: "setDOM",
     setNodeEvent: "setNodeEvent",
@@ -38,9 +46,21 @@ describe("useEditor", () => {
     expect(useInternalEditor).toHaveBeenCalledWith(collect);
   });
   it("should return the correct editor", () => {
+    // useEditor will remove replaceNodes, reset, replaceEvents
+    const {
+      replaceNodes,
+      reset,
+      replaceEvents,
+      ...runWithoutHistory
+    } = otherActions.runWithoutHistory;
+
     expect(editor).toEqual(
       expect.objectContaining({
-        actions: { ...otherActions, selectNode: expect.any(Function) },
+        actions: {
+          ...otherActions,
+          runWithoutHistory,
+          selectNode: expect.any(Function),
+        },
         connectors: state.connectors,
         query: otherQueries,
         aRandomValue: state.aRandomValue,

--- a/packages/core/src/hooks/useEditor.tsx
+++ b/packages/core/src/hooks/useEditor.tsx
@@ -11,9 +11,13 @@ export type useEditor<S = null> = Overwrite<
   {
     actions: Delete<
       useInternalEditor<S>["actions"],
-      "setNodeEvent" | "setDOM" | "replaceNodes" | "reset"
+      "setNodeEvent" | "setDOM" | "replaceNodes" | "reset" | "runWithoutHistory"
     > & {
       selectNode: (nodeId: NodeId | null) => void;
+      runWithoutHistory: Delete<
+        useInternalEditor<S>["actions"]["runWithoutHistory"],
+        "replaceNodes" | "reset"
+      >;
     };
     query: Delete<useInternalEditor<S>["query"], "deserialize">;
   }
@@ -29,7 +33,19 @@ export function useEditor<S>(collect: EditorCollector<S>): useEditor<S>;
 export function useEditor<S>(collect?: any): useEditor<S> {
   const {
     connectors,
-    actions: { setDOM, setNodeEvent, replaceNodes, reset, ...EditorActions },
+    actions: {
+      setDOM,
+      setNodeEvent,
+      replaceNodes,
+      reset,
+      runWithoutHistory: {
+        replaceNodes: _,
+        replaceEvents: __,
+        reset: ___,
+        ...runWithoutHistory
+      },
+      ...EditorActions
+    },
     query: { deserialize, ...query },
     store,
     ...collected
@@ -42,6 +58,7 @@ export function useEditor<S>(collect?: any): useEditor<S> {
         setNodeEvent("selected", nodeId);
         setNodeEvent("hovered", null);
       },
+      runWithoutHistory,
     };
   }, [EditorActions, setNodeEvent]);
 

--- a/packages/core/src/hooks/useEditor.tsx
+++ b/packages/core/src/hooks/useEditor.tsx
@@ -4,9 +4,7 @@ import {
 } from "../editor/useInternalEditor";
 import { useMemo } from "react";
 import { NodeId } from "../interfaces";
-
-type Overwrite<T, U> = Pick<T, Exclude<keyof T, keyof U>> & U;
-type Delete<T, U> = Pick<T, Exclude<keyof T, U>>;
+import { Overwrite, Delete } from "@candulabs/craft-utils";
 
 export type useEditor<S = null> = Overwrite<
   useInternalEditor<S>,

--- a/packages/core/src/nodes/Canvas.tsx
+++ b/packages/core/src/nodes/Canvas.tsx
@@ -32,7 +32,7 @@ export function Canvas<T extends React.ElementType>({
 }: Canvas<T>) {
   const id = props.id;
   const {
-    actions: { add, setProp },
+    actions: { setProp, silent },
     query,
     inContext,
     store,
@@ -48,7 +48,6 @@ export function Canvas<T extends React.ElementType>({
 
   /** Only create/recreate nodes on the initial render. From there on, the re-renders will be handled by Nodes */
   useEffectOnce(() => {
-    store.history.unwatch();
     const { id: nodeId, data } = node;
     if (inContext && inNodeContext) {
       if (data.isCanvas) {
@@ -58,7 +57,7 @@ export function Canvas<T extends React.ElementType>({
             query.createNode(jsx)
           );
 
-          add(childNodes, nodeId);
+          silent("add", childNodes, nodeId);
         }
       } else {
         invariant(id, ERROR_ROOT_CANVAS_NO_ID);
@@ -90,7 +89,7 @@ export function Canvas<T extends React.ElementType>({
         );
 
         internalId = rootNode.id;
-        add(rootNode, nodeId);
+        silent("add", rootNode, nodeId);
 
         setInternalId(internalId);
       }
@@ -98,16 +97,6 @@ export function Canvas<T extends React.ElementType>({
 
     setInitialised(true);
   });
-
-  /*
-   TODO: Using a timeout to renable history for now 
-   because we can't really be sure if the current action has been completed
-  */
-  useEffect(() => {
-    setTimeout(() => {
-      if (initialised) store.history.watch();
-    });
-  }, [initialised, store]);
 
   /**
    *

--- a/packages/core/src/nodes/Canvas.tsx
+++ b/packages/core/src/nodes/Canvas.tsx
@@ -35,6 +35,7 @@ export function Canvas<T extends React.ElementType>({
     actions: { add, setProp },
     query,
     inContext,
+    store,
   } = useInternalEditor();
   const { node, inNodeContext } = useInternalNode((node) => ({
     node: {
@@ -47,6 +48,7 @@ export function Canvas<T extends React.ElementType>({
 
   /** Only create/recreate nodes on the initial render. From there on, the re-renders will be handled by Nodes */
   useEffectOnce(() => {
+    store.history.unwatch();
     const { id: nodeId, data } = node;
     if (inContext && inNodeContext) {
       if (data.isCanvas) {
@@ -96,6 +98,16 @@ export function Canvas<T extends React.ElementType>({
 
     setInitialised(true);
   });
+
+  /*
+   TODO: Using a timeout to renable history for now 
+   because we can't really be sure if the current action has been completed
+  */
+  useEffect(() => {
+    setTimeout(() => {
+      if (initialised) store.history.watch();
+    });
+  }, [initialised, store]);
 
   /**
    *

--- a/packages/core/src/nodes/Canvas.tsx
+++ b/packages/core/src/nodes/Canvas.tsx
@@ -32,10 +32,9 @@ export function Canvas<T extends React.ElementType>({
 }: Canvas<T>) {
   const id = props.id;
   const {
-    actions: { setProp, silent },
+    actions: { setProp, runWithoutHistory },
     query,
     inContext,
-    store,
   } = useInternalEditor();
   const { node, inNodeContext } = useInternalNode((node) => ({
     node: {
@@ -57,7 +56,7 @@ export function Canvas<T extends React.ElementType>({
             query.createNode(jsx)
           );
 
-          silent("add", childNodes, nodeId);
+          runWithoutHistory.add(childNodes, nodeId);
         }
       } else {
         invariant(id, ERROR_ROOT_CANVAS_NO_ID);
@@ -89,7 +88,7 @@ export function Canvas<T extends React.ElementType>({
         );
 
         internalId = rootNode.id;
-        silent("add", rootNode, nodeId);
+        runWithoutHistory.add(rootNode, nodeId);
 
         setInternalId(internalId);
       }

--- a/packages/core/src/render/Frame.tsx
+++ b/packages/core/src/render/Frame.tsx
@@ -31,12 +31,12 @@ export const Frame: React.FC<Frame> = ({ children, json, data }) => {
   });
 
   useEffect(() => {
-    const { replaceNodes, setState } = actions;
+    const { silent } = actions;
     const { createNode } = query;
     const { initialChildren, initialData } = initialState.current;
 
     if (initialData) {
-      setState(initialData);
+      silent("setState", initialData);
     } else if (initialChildren) {
       const rootCanvas = React.Children.only(
         initialChildren
@@ -47,7 +47,7 @@ export const Frame: React.FC<Frame> = ({ children, json, data }) => {
         ERROR_FRAME_IMMEDIATE_NON_CANVAS
       );
       const node = createNode(rootCanvas, { id: ROOT_NODE });
-      replaceNodes({ [ROOT_NODE]: node });
+      silent("replaceNodes", { [ROOT_NODE]: node });
     }
 
     setRender(<NodeElement id={ROOT_NODE} />);

--- a/packages/core/src/render/Frame.tsx
+++ b/packages/core/src/render/Frame.tsx
@@ -31,12 +31,12 @@ export const Frame: React.FC<Frame> = ({ children, json, data }) => {
   });
 
   useEffect(() => {
-    const { silent } = actions;
+    const { runWithoutHistory } = actions;
     const { createNode } = query;
     const { initialChildren, initialData } = initialState.current;
 
     if (initialData) {
-      silent("setState", initialData);
+      runWithoutHistory.setState(initialData);
     } else if (initialChildren) {
       const rootCanvas = React.Children.only(
         initialChildren
@@ -47,7 +47,7 @@ export const Frame: React.FC<Frame> = ({ children, json, data }) => {
         ERROR_FRAME_IMMEDIATE_NON_CANVAS
       );
       const node = createNode(rootCanvas, { id: ROOT_NODE });
-      silent("replaceNodes", { [ROOT_NODE]: node });
+      runWithoutHistory.replaceNodes({ [ROOT_NODE]: node });
     }
 
     setRender(<NodeElement id={ROOT_NODE} />);

--- a/packages/core/src/render/tests/Frame.test.tsx
+++ b/packages/core/src/render/tests/Frame.test.tsx
@@ -23,7 +23,9 @@ describe("<Frame />", () => {
   let query;
 
   beforeEach(() => {
-    actions = { silent: jest.fn() };
+    actions = {
+      runWithoutHistory: { setState: jest.fn(), replaceNodes: jest.fn() },
+    };
     query = { createNode: jest.fn() };
     mockEditor.mockImplementation(() => ({ actions, query }));
   });
@@ -42,7 +44,9 @@ describe("<Frame />", () => {
       mount(<Frame json={json} />);
     });
     it("should parse json and call setState", () => {
-      expect(actions.silent).toHaveBeenCalledWith("setState", JSON.parse(json));
+      expect(actions.runWithoutHistory.setState).toHaveBeenCalledWith(
+        JSON.parse(json)
+      );
     });
   });
 
@@ -51,7 +55,7 @@ describe("<Frame />", () => {
       mount(<Frame data={data} />);
     });
     it("should deserialize the nodes", () => {
-      expect(actions.silent).toHaveBeenCalledWith("setState", data);
+      expect(actions.runWithoutHistory.setState).toHaveBeenCalledWith(data);
     });
   });
 });

--- a/packages/core/src/render/tests/Frame.test.tsx
+++ b/packages/core/src/render/tests/Frame.test.tsx
@@ -23,7 +23,7 @@ describe("<Frame />", () => {
   let query;
 
   beforeEach(() => {
-    actions = { replaceNodes: jest.fn(), setState: jest.fn() };
+    actions = { silent: jest.fn() };
     query = { createNode: jest.fn() };
     mockEditor.mockImplementation(() => ({ actions, query }));
   });
@@ -42,7 +42,7 @@ describe("<Frame />", () => {
       mount(<Frame json={json} />);
     });
     it("should parse json and call setState", () => {
-      expect(actions.setState).toHaveBeenCalledWith(JSON.parse(json));
+      expect(actions.silent).toHaveBeenCalledWith("setState", JSON.parse(json));
     });
   });
 
@@ -51,7 +51,7 @@ describe("<Frame />", () => {
       mount(<Frame data={data} />);
     });
     it("should deserialize the nodes", () => {
-      expect(actions.setState).toHaveBeenCalledWith(data);
+      expect(actions.silent).toHaveBeenCalledWith("setState", data);
     });
   });
 });

--- a/packages/examples/basic/components/Topbar.js
+++ b/packages/examples/basic/components/Topbar.js
@@ -21,8 +21,8 @@ export const Topbar = ({ onLoadState }) => {
     (state, query) => {
       return {
         enabled: state.options.enabled,
-        undoable: query["canUndo"](),
-        redoable: query["canRedo"](),
+        undoable: query.canUndo(),
+        redoable: query.canRedo(),
       };
     }
   );

--- a/packages/examples/basic/components/Topbar.js
+++ b/packages/examples/basic/components/Topbar.js
@@ -17,9 +17,15 @@ import lz from "lzutf8";
 import copy from "copy-to-clipboard";
 
 export const Topbar = ({ onLoadState }) => {
-  const { actions, query, enabled } = useEditor((state) => ({
-    enabled: state.options.enabled,
-  }));
+  const { actions, query, enabled, undoable, redoable } = useEditor(
+    (state, query) => {
+      return {
+        enabled: state.options.enabled,
+        undoable: query["canUndo"](),
+        redoable: query["canRedo"](),
+      };
+    }
+  );
 
   const [dialogOpen, setDialogOpen] = useState(false);
   const [snackbarMessage, setSnackbarMessage] = useState();
@@ -42,6 +48,31 @@ export const Topbar = ({ onLoadState }) => {
             }
             label="Enable"
           />
+          <MaterialButton
+            size="small"
+            variant="outlined"
+            color="secondary"
+            onClick={() => {
+              actions.undo();
+            }}
+            style={{ marginRight: "10px" }}
+            disabled={!undoable}
+          >
+            Undo
+          </MaterialButton>
+
+          <MaterialButton
+            size="small"
+            variant="outlined"
+            color="secondary"
+            onClick={() => {
+              actions.redo();
+            }}
+            style={{ marginRight: "10px" }}
+            disabled={!redoable}
+          >
+            Redo
+          </MaterialButton>
         </Grid>
         <Grid item>
           <MaterialButton

--- a/packages/utils/src/History.ts
+++ b/packages/utils/src/History.ts
@@ -1,0 +1,71 @@
+import { Patch, applyPatches } from "immer";
+import isEqualWith from "lodash.isequalwith";
+
+type Timeline = Array<{
+  patches: Patch[];
+  inversePatches: Patch[];
+}>;
+
+export class History {
+  timeline: Timeline = [];
+  pointer = -1;
+  lastChange;
+
+  add(patches, inversePatches, action) {
+    if (patches.length == 0 && inversePatches.length == 0) return;
+
+    if (this.canUndo()) {
+      const { patches: currPatches } = this.timeline[this.pointer];
+
+      const now = new Date();
+      const diff = (now.getTime() - this.lastChange.getTime()) / 1000;
+
+      // Ignore similar changes that occurs within 2 seconds
+      if (diff < 2 && currPatches.length == patches.length) {
+        const isSimilar = currPatches.every((currPatch, i) => {
+          const { op: currOp, path: currPath } = currPatch;
+          const { op, path } = patches[i];
+
+          if (op == currOp && isEqualWith(path, currPath)) return true;
+          return false;
+        });
+
+        if (isSimilar) {
+          return;
+        }
+      }
+    }
+
+    this.pointer = this.pointer + 1;
+    this.timeline.length = this.pointer;
+    this.timeline[this.pointer] = { patches, inversePatches };
+
+    this.lastChange = new Date();
+  }
+
+  canUndo() {
+    return this.pointer >= 0;
+  }
+
+  canRedo() {
+    return this.pointer != this.timeline.length - 1;
+  }
+
+  undo(state) {
+    if (this.canUndo()) {
+      const { inversePatches } = this.timeline[this.pointer];
+      this.pointer = this.pointer - 1;
+      const applied = applyPatches(state, inversePatches);
+      return applied;
+    }
+  }
+
+  redo(state) {
+    if (this.canRedo()) {
+      this.pointer = this.pointer + 1;
+      const { patches } = this.timeline[this.pointer];
+      const applied = applyPatches(state, patches);
+      return applied;
+    }
+  }
+}

--- a/packages/utils/src/History.ts
+++ b/packages/utils/src/History.ts
@@ -1,5 +1,4 @@
 import { Patch, applyPatches } from "immer";
-import isEqualWith from "lodash.isequalwith";
 
 type Timeline = Array<{
   patches: Patch[];
@@ -11,30 +10,8 @@ export class History {
   pointer = -1;
   lastChange;
 
-  add(patches, inversePatches, action) {
+  add(patches, inversePatches) {
     if (patches.length == 0 && inversePatches.length == 0) return;
-
-    if (this.canUndo()) {
-      const { patches: currPatches } = this.timeline[this.pointer];
-
-      const now = new Date();
-      const diff = (now.getTime() - this.lastChange.getTime()) / 1000;
-
-      // Ignore similar changes that occurs within 2 seconds
-      if (diff < 2 && currPatches.length == patches.length) {
-        const isSimilar = currPatches.every((currPatch, i) => {
-          const { op: currOp, path: currPath } = currPatch;
-          const { op, path } = patches[i];
-
-          if (op == currOp && isEqualWith(path, currPath)) return true;
-          return false;
-        });
-
-        if (isSimilar) {
-          return;
-        }
-      }
-    }
 
     this.pointer = this.pointer + 1;
     this.timeline.length = this.pointer;

--- a/packages/utils/src/History.ts
+++ b/packages/utils/src/History.ts
@@ -8,16 +8,13 @@ type Timeline = Array<{
 export class History {
   timeline: Timeline = [];
   pointer = -1;
-  lastChange;
 
-  add(patches, inversePatches) {
+  add(patches: Patch[], inversePatches: Patch[]) {
     if (patches.length == 0 && inversePatches.length == 0) return;
 
     this.pointer = this.pointer + 1;
     this.timeline.length = this.pointer;
     this.timeline[this.pointer] = { patches, inversePatches };
-
-    this.lastChange = new Date();
   }
 
   canUndo() {
@@ -29,20 +26,21 @@ export class History {
   }
 
   undo(state) {
-    if (this.canUndo()) {
-      const { inversePatches } = this.timeline[this.pointer];
-      this.pointer = this.pointer - 1;
-      const applied = applyPatches(state, inversePatches);
-      return applied;
-    }
+    if (!this.canUndo()) return;
+
+    const { inversePatches } = this.timeline[this.pointer];
+    this.pointer = this.pointer - 1;
+    const applied = applyPatches(state, inversePatches);
+
+    return applied;
   }
 
   redo(state) {
-    if (this.canRedo()) {
-      this.pointer = this.pointer + 1;
-      const { patches } = this.timeline[this.pointer];
-      const applied = applyPatches(state, patches);
-      return applied;
-    }
+    if (!this.canRedo()) return;
+
+    this.pointer = this.pointer + 1;
+    const { patches } = this.timeline[this.pointer];
+    const applied = applyPatches(state, patches);
+    return applied;
   }
 }

--- a/packages/utils/src/History.ts
+++ b/packages/utils/src/History.ts
@@ -10,7 +10,9 @@ export class History {
   pointer = -1;
 
   add(patches: Patch[], inversePatches: Patch[]) {
-    if (patches.length == 0 && inversePatches.length == 0) return;
+    if (patches.length == 0 && inversePatches.length == 0) {
+      return;
+    }
 
     this.pointer = this.pointer + 1;
     this.timeline.length = this.pointer;
@@ -22,11 +24,13 @@ export class History {
   }
 
   canRedo() {
-    return this.pointer != this.timeline.length - 1;
+    return this.pointer < this.timeline.length - 1;
   }
 
   undo(state) {
-    if (!this.canUndo()) return;
+    if (!this.canUndo()) {
+      return;
+    }
 
     const { inversePatches } = this.timeline[this.pointer];
     this.pointer = this.pointer - 1;
@@ -36,7 +40,9 @@ export class History {
   }
 
   redo(state) {
-    if (!this.canRedo()) return;
+    if (!this.canRedo()) {
+      return;
+    }
 
     this.pointer = this.pointer + 1;
     const { patches } = this.timeline[this.pointer];

--- a/packages/utils/src/__tests__/History.spec.ts
+++ b/packages/utils/src/__tests__/History.spec.ts
@@ -1,0 +1,68 @@
+import { History } from "../History";
+import { applyPatches } from "immer";
+
+jest.mock("immer");
+
+describe("History Manager", () => {
+  let history,
+    dummyTimeline = [
+      {
+        patches: [{ op: "add", path: "/node1", value: 32 }],
+        inversePatches: [],
+        state: { node1: 32 },
+      },
+      {
+        patches: [{ op: "add", path: "/node2", value: 55 }],
+        inversePatches: [{ op: "add", path: "/node1", value: 32 }],
+        state: { node1: 32, node2: 55 },
+      },
+    ];
+
+  describe("Adding patches to timeline", () => {
+    beforeEach(() => {
+      history = new History();
+    });
+
+    const { patches, inversePatches } = dummyTimeline[0];
+
+    it("should add history to timeline", () => {
+      history.add(patches, inversePatches);
+      expect(history.timeline).toMatchObject([{ patches, inversePatches }]);
+    });
+
+    it("should ignore adding empty history to timeline", () => {
+      history.add([], []);
+      expect(history.timeline).toMatchObject([]);
+    });
+  });
+
+  describe("Undo/Redo actions", () => {
+    beforeAll(() => {
+      history = new History();
+      history.add(dummyTimeline[0].patches, dummyTimeline[0].inversePatches);
+      history.add(dummyTimeline[1].patches, dummyTimeline[1].inversePatches);
+    });
+
+    it("should be able to undo", () => {
+      const { state, inversePatches } = dummyTimeline[1];
+      history.undo(state);
+      expect(applyPatches).toHaveBeenCalledWith(state, inversePatches);
+    });
+
+    it("should be able to redo", () => {
+      const { state } = dummyTimeline[0];
+      const { patches } = dummyTimeline[1];
+      history.redo(state);
+      expect(applyPatches).toHaveBeenCalledWith(state, patches);
+    });
+
+    it("should prevent redo if a change occured after undo", () => {
+      history.undo(dummyTimeline[1].state);
+      history.add(
+        [{ op: "add", path: "/node1", value: 1000 }],
+        dummyTimeline[0].patches
+      );
+      expect(history.canRedo()).toEqual(false);
+    });
+  });
+});

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -6,3 +6,4 @@ export * from "./wrapConnectorHooks";
 export * from "./RenderIndicator";
 export * from "./useEffectOnce";
 export * from "./Handlers";
+export * from "./utilityTypes";

--- a/packages/utils/src/useCollector.tsx
+++ b/packages/utils/src/useCollector.tsx
@@ -1,30 +1,31 @@
 import { useState, useCallback, useRef, useEffect } from "react";
 import {
   CallbacksFor,
-  Methods,
+  MethodsOrOptions,
   StateFor,
   QueryCallbacksFor,
   QueryMethods,
   SubscriberAndCallbacksFor,
 } from "./useMethods";
 
-type Actions<M extends Methods, Q extends QueryMethods> = {
+type Actions<M extends MethodsOrOptions, Q extends QueryMethods> = {
   actions: CallbacksFor<M>;
   query: QueryCallbacksFor<Q>;
 };
 
 export type useCollector<
-  M extends Methods,
+  M extends MethodsOrOptions,
   Q extends QueryMethods | null,
   C = null
 > = C extends null ? Actions<M, Q> : C & Actions<M, Q>;
 
-export function useCollector<M extends Methods, Q extends QueryMethods | null>(
-  store: SubscriberAndCallbacksFor<M, Q>
-): useCollector<M, Q>;
+export function useCollector<
+  M extends MethodsOrOptions,
+  Q extends QueryMethods | null
+>(store: SubscriberAndCallbacksFor<M, Q>): useCollector<M, Q>;
 
 export function useCollector<
-  M extends Methods,
+  M extends MethodsOrOptions,
   Q extends QueryMethods | null,
   C
 >(
@@ -33,7 +34,7 @@ export function useCollector<
 ): useCollector<M, Q, C>;
 
 export function useCollector<
-  M extends Methods,
+  M extends MethodsOrOptions,
   Q extends QueryMethods | null,
   C
 >(store: SubscriberAndCallbacksFor<M, Q>, collector?: any) {

--- a/packages/utils/src/useMethods.ts
+++ b/packages/utils/src/useMethods.ts
@@ -168,8 +168,9 @@ export function useMethods<
                 "redo",
                 "runWithoutHistory",
               ].includes(action.type as any)
-            )
+            ) {
               return;
+            }
 
             applyPatches(state, patches);
             history.add(patches, inversePatches);

--- a/packages/utils/src/utilityTypes.ts
+++ b/packages/utils/src/utilityTypes.ts
@@ -1,0 +1,2 @@
+export type Overwrite<T, U> = Pick<T, Exclude<keyof T, keyof U>> & U;
+export type Delete<T, U> = Pick<T, Exclude<keyof T, U>>;


### PR DESCRIPTION
# New

Implements the History API (undo/redo) 

```jsx
const { actions: {undo, redo}, undoable, redoable } = useEditor((_, query) => ({ 
   undoable: query.canUndo(),
   redoable: query.canRedo() 
}))

<btn onClick={() => actions.undo()} disabled={!undoable}>Undo</btn>

```

# Testing
- [x] Localhost


# Screenshots

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/16416929/80084059-f3c45c00-8588-11ea-9c33-e1c33362722d.gif)
