### PR TITLE
Normalize History on undo/redo

### DIFF
--- a/packages/core/src/editor/store.tsx
+++ b/packages/core/src/editor/store.tsx
@@ -10,6 +10,18 @@ export const ActionMethodsWithConfig = {
     "setOptions",
     "setIndicator",
   ] as const,
+  normalizeHistory: (state) => {
+    /**
+     * On every undo/redo, we want to reset these values
+     * because their changes are not tracked by the history manager
+     */
+    state.events = {
+      selected: null,
+      dragged: null,
+      hovered: null,
+      indicator: null,
+    };
+  },
 };
 
 export type EditorStore = SubscriberAndCallbacksFor<


### PR DESCRIPTION
# New
Whenever the undo and redo function is called, we call a function to normalise the history (eg: reset certain state properties)

# Testing
- [ ] Unit
- [ ] Integration
- [x] Localhost
