### PR TITLE
Add state normalising function

### DIFF
--- a/packages/core/src/editor/Editor.tsx
+++ b/packages/core/src/editor/Editor.tsx
@@ -5,7 +5,6 @@ import { Events } from "../events";
 
 import { useEditorStore } from "./store";
 import { EditorContext } from "./EditorContext";
-import { original } from "immer";
 
 export const withDefaults = (options: Partial<Options> = {}) => ({
   onStateChange: () => null,

--- a/packages/core/src/editor/Editor.tsx
+++ b/packages/core/src/editor/Editor.tsx
@@ -25,29 +25,19 @@ export const withDefaults = (options: Partial<Options> = {}) => ({
  */
 export const Editor: React.FC<Partial<Options>> = ({
   children,
+  normaliseNodes,
   ...options
 }) => {
-  const initialised = useRef(false);
-
   const context = useEditorStore(
     withDefaults(options),
-    (patches, draft, type) => {
-      if (!initialised.current) {
-        return;
-      }
-
+    (draft, previousState, action, patches) => {
       for (let i = 0; i < patches.length; i++) {
-        const { path, value } = patches[i];
-        // If data is modified:
+        const { path } = patches[i];
         if (path.length > 2 && path[0] == "nodes" && path[2] == "data") {
-          // Object.keys(draft.nodes).forEach(id => {
-          //   const node = draft.nodes[id];
-          //   if ( node.data.name == "Button" ) {
-          //     node.data.props.size = "large";
-          //   }
-          // })
-          console.log("changed!", patches[i], type);
-          break;
+          if (normaliseNodes) {
+            normaliseNodes(draft, previousState, action);
+          }
+          break; // we exit the loop as soon as we find a change in node.data
         }
       }
     }
@@ -66,8 +56,6 @@ export const Editor: React.FC<Partial<Options>> = ({
         json: context.query.serialize(),
       }),
       ({ json }) => {
-        console.log("Test");
-        initialised.current = true;
         context.query.getOptions().onStateChange(JSON.parse(json));
       }
     );

--- a/packages/core/src/editor/Editor.tsx
+++ b/packages/core/src/editor/Editor.tsx
@@ -66,8 +66,8 @@ export const Editor: React.FC<Partial<Options>> = ({
         json: context.query.serialize(),
       }),
       ({ json }) => {
+        console.log("Test");
         initialised.current = true;
-        console.log("test");
         context.query.getOptions().onStateChange(JSON.parse(json));
       }
     );

--- a/packages/core/src/editor/Editor.tsx
+++ b/packages/core/src/editor/Editor.tsx
@@ -35,7 +35,7 @@ export const Editor: React.FC<Partial<Options>> = ({
         const { path } = patches[i];
         if (path.length > 2 && path[0] == "nodes" && path[2] == "data") {
           if (normaliseNodes) {
-            normaliseNodes(draft, previousState, action, query);
+            normaliseNodes(draft, previousState, actionPerformed, query);
           }
           break; // we exit the loop as soon as we find a change in node.data
         }

--- a/packages/core/src/editor/Editor.tsx
+++ b/packages/core/src/editor/Editor.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from "react";
+import React, { useEffect } from "react";
 
 import { Options } from "../interfaces";
 import { Events } from "../events";

--- a/packages/core/src/editor/Editor.tsx
+++ b/packages/core/src/editor/Editor.tsx
@@ -29,8 +29,8 @@ export const Editor: React.FC<Partial<Options>> = ({
 }) => {
   const context = useEditorStore(
     withDefaults(options),
-    (draft, previousState, actionPerformed, query) => {
-      const { patches, ...action } = actionPerformed;
+    (draft, previousState, actionPerformedWithPatches, query) => {
+      const { patches, ...actionPerformed } = actionPerformedWithPatches;
       for (let i = 0; i < patches.length; i++) {
         const { path } = patches[i];
         if (path.length > 2 && path[0] == "nodes" && path[2] == "data") {

--- a/packages/core/src/editor/Editor.tsx
+++ b/packages/core/src/editor/Editor.tsx
@@ -29,12 +29,13 @@ export const Editor: React.FC<Partial<Options>> = ({
 }) => {
   const context = useEditorStore(
     withDefaults(options),
-    (draft, previousState, action, patches) => {
+    (draft, previousState, actionPerformed, query) => {
+      const { patches, ...action } = actionPerformed;
       for (let i = 0; i < patches.length; i++) {
         const { path } = patches[i];
         if (path.length > 2 && path[0] == "nodes" && path[2] == "data") {
           if (normaliseNodes) {
-            normaliseNodes(draft, previousState, action);
+            normaliseNodes(draft, previousState, action, query);
           }
           break; // we exit the loop as soon as we find a change in node.data
         }

--- a/packages/core/src/editor/store.tsx
+++ b/packages/core/src/editor/store.tsx
@@ -1,6 +1,11 @@
-import { useMethods, SubscriberAndCallbacksFor } from "@candulabs/craft-utils";
+import {
+  useMethods,
+  SubscriberAndCallbacksFor,
+  PatchListener,
+} from "@candulabs/craft-utils";
 import { Actions } from "./actions";
 import { QueryMethods } from "./query";
+import { EditorState } from "../interfaces";
 
 export const ActionMethodsWithConfig = {
   methods: Actions,
@@ -29,7 +34,10 @@ export type EditorStore = SubscriberAndCallbacksFor<
   typeof QueryMethods
 >;
 
-export const useEditorStore = (options, patchListener): EditorStore => {
+export const useEditorStore = (
+  options,
+  patchListener: PatchListener<EditorState, typeof ActionMethodsWithConfig>
+): EditorStore => {
   return useMethods(
     ActionMethodsWithConfig,
     {

--- a/packages/core/src/editor/store.tsx
+++ b/packages/core/src/editor/store.tsx
@@ -22,7 +22,7 @@ export const ActionMethodsWithConfig = {
       indicator: null,
     };
   },
-} as any;
+};
 
 export type EditorStore = SubscriberAndCallbacksFor<
   typeof ActionMethodsWithConfig,

--- a/packages/core/src/editor/store.tsx
+++ b/packages/core/src/editor/store.tsx
@@ -36,7 +36,11 @@ export type EditorStore = SubscriberAndCallbacksFor<
 
 export const useEditorStore = (
   options,
-  patchListener: PatchListener<EditorState, typeof ActionMethodsWithConfig>
+  patchListener: PatchListener<
+    EditorState,
+    typeof ActionMethodsWithConfig,
+    typeof QueryMethods
+  >
 ): EditorStore => {
   return useMethods(
     ActionMethodsWithConfig,

--- a/packages/core/src/editor/store.tsx
+++ b/packages/core/src/editor/store.tsx
@@ -22,14 +22,14 @@ export const ActionMethodsWithConfig = {
       indicator: null,
     };
   },
-};
+} as any;
 
 export type EditorStore = SubscriberAndCallbacksFor<
   typeof ActionMethodsWithConfig,
   typeof QueryMethods
 >;
 
-export const useEditorStore = (options): EditorStore => {
+export const useEditorStore = (options, patchListener): EditorStore => {
   return useMethods(
     ActionMethodsWithConfig,
     {
@@ -42,6 +42,7 @@ export const useEditorStore = (options): EditorStore => {
       },
       options,
     },
-    QueryMethods
+    QueryMethods,
+    patchListener
   ) as EditorStore;
 };

--- a/packages/core/src/events/EventHandlers.ts
+++ b/packages/core/src/events/EventHandlers.ts
@@ -34,10 +34,10 @@ export class EventHandlers extends Handlers<
         events: [
           event({
             name: "mousedown",
-            handler: rapidDebounce((_, id: NodeId) =>
-              this.store.actions.setNodeEvent("selected", id)
-            ),
-            capture: true,
+            handler: (e, id: NodeId) => {
+              e.stopPropagation();
+              this.store.actions.setNodeEvent("selected", id);
+            },
           }),
         ],
       },

--- a/packages/core/src/events/tests/EventHandlers.test.ts
+++ b/packages/core/src/events/tests/EventHandlers.test.ts
@@ -63,7 +63,10 @@ describe("EventHandlers", () => {
       expect(getHandler(select.events, "mousedown")).toBeDefined();
     });
     it("should call setNodeEvent on mousedown", () => {
-      callHandler(select.events, "mousedown")(null, nodeId);
+      callHandler(select.events, "mousedown")(
+        { stopPropagation: jest.fn() },
+        nodeId
+      );
       expect(actions.setNodeEvent).toHaveBeenCalledWith("selected", nodeId);
     });
   });

--- a/packages/core/src/hooks/useEditor.tsx
+++ b/packages/core/src/hooks/useEditor.tsx
@@ -60,7 +60,7 @@ export function useEditor<S>(collect?: any): useEditor<S> {
       },
       runWithoutHistory,
     };
-  }, [EditorActions, setNodeEvent]);
+  }, [EditorActions, runWithoutHistory, setNodeEvent]);
 
   return {
     connectors,

--- a/packages/core/src/interfaces/editor.ts
+++ b/packages/core/src/interfaces/editor.ts
@@ -1,22 +1,29 @@
 import { Nodes, NodeEvents, NodeId } from "./nodes";
 import { Placement } from "./events";
 import { useInternalEditor } from "../editor/useInternalEditor";
-import { PatchListenerAction } from "@candulabs/craft-utils";
+import {
+  CallbacksFor,
+  Delete,
+  PatchListenerAction,
+  QueryCallbacksFor,
+} from "@candulabs/craft-utils";
 import { ActionMethodsWithConfig } from "../editor/store";
+import { QueryMethods } from "../editor/query";
 
 export type Options = {
   onRender: React.ComponentType<{ render: React.ReactElement }>;
-  onStateChange: (Nodes) => any;
+  onStateChange: (nodes: Nodes) => void;
   resolver: Resolver;
   enabled: boolean;
   indicator: Record<"success" | "error", string>;
   normaliseNodes: (
     state: EditorState,
     previousState: EditorState,
-    actionPerformed: PatchListenerAction<
-      EditorState,
-      typeof ActionMethodsWithConfig
-    >
+    actionPerformed: Delete<
+      PatchListenerAction<EditorState, typeof ActionMethodsWithConfig>,
+      "patches"
+    >,
+    query: QueryCallbacksFor<typeof QueryMethods>
   ) => void;
 };
 

--- a/packages/core/src/interfaces/editor.ts
+++ b/packages/core/src/interfaces/editor.ts
@@ -1,6 +1,8 @@
 import { Nodes, NodeEvents, NodeId } from "./nodes";
 import { Placement } from "./events";
 import { useInternalEditor } from "../editor/useInternalEditor";
+import { PatchListenerAction } from "@candulabs/craft-utils";
+import { ActionMethodsWithConfig } from "../editor/store";
 
 export type Options = {
   onRender: React.ComponentType<{ render: React.ReactElement }>;
@@ -8,6 +10,14 @@ export type Options = {
   resolver: Resolver;
   enabled: boolean;
   indicator: Record<"success" | "error", string>;
+  normaliseNodes: (
+    state: EditorState,
+    previousState: EditorState,
+    actionPerformed: PatchListenerAction<
+      EditorState,
+      typeof ActionMethodsWithConfig
+    >
+  ) => void;
 };
 
 export type Resolver = Record<string, string | React.ElementType>;

--- a/packages/core/src/interfaces/nodes.ts
+++ b/packages/core/src/interfaces/nodes.ts
@@ -6,6 +6,7 @@ type UserComponentConfig<T> = {
   name: string;
   rules: Partial<NodeRules>;
   related: Partial<NodeRelated>;
+  normalise: NodeNormaliseCreator;
   defaultProps: Partial<T>;
 };
 
@@ -32,6 +33,15 @@ export type NodeRules = {
   canMoveIn(canMoveIn: Node, self: Node, helpers: NodeHelpers): boolean;
   canMoveOut(canMoveOut: Node, self: Node, helpers: NodeHelpers): boolean;
 };
+export type NodeNormalise = {
+  onAdd(): void;
+  onDelete(): void;
+  onMove(): void;
+  onChildAdd(child: Node): void;
+  onChildRemove(child: Node): void;
+  onChildMove(child: Node): void;
+};
+export type NodeNormaliseCreator = (node: Node, query: any) => NodeNormalise;
 export type NodeRelated = Record<string, React.ElementType>;
 
 export type NodeData = {

--- a/packages/core/src/interfaces/nodes.ts
+++ b/packages/core/src/interfaces/nodes.ts
@@ -6,7 +6,6 @@ type UserComponentConfig<T> = {
   name: string;
   rules: Partial<NodeRules>;
   related: Partial<NodeRelated>;
-  normalise: NodeNormaliseCreator;
   defaultProps: Partial<T>;
 };
 
@@ -33,15 +32,6 @@ export type NodeRules = {
   canMoveIn(canMoveIn: Node, self: Node, helpers: NodeHelpers): boolean;
   canMoveOut(canMoveOut: Node, self: Node, helpers: NodeHelpers): boolean;
 };
-export type NodeNormalise = {
-  onAdd(): void;
-  onDelete(): void;
-  onMove(): void;
-  onChildAdd(child: Node): void;
-  onChildRemove(child: Node): void;
-  onChildMove(child: Node): void;
-};
-export type NodeNormaliseCreator = (node: Node, query: any) => NodeNormalise;
 export type NodeRelated = Record<string, React.ElementType>;
 
 export type NodeData = {

--- a/packages/core/src/nodes/NodeContext.tsx
+++ b/packages/core/src/nodes/NodeContext.tsx
@@ -1,6 +1,7 @@
-import React from "react";
+import React, { useMemo } from "react";
 import { NodeId } from "../interfaces";
-import { NodeConnectors } from "./NodeHandlers";
+import { NodeConnectors, NodeHandlers } from "./NodeHandlers";
+import { useEventHandler } from "../events";
 
 export const NodeContext = React.createContext<any>(null);
 
@@ -13,9 +14,14 @@ export type NodeProvider = {
 export const NodeProvider: React.FC<NodeProvider> = ({
   id,
   related = false,
-  connectors,
   children,
 }) => {
+  const handlers = useEventHandler();
+  const connectors = useMemo(
+    () => handlers.derive(NodeHandlers, id).connectors(),
+    [handlers, id]
+  );
+
   return (
     <NodeContext.Provider value={{ id, related, connectors }}>
       {children}

--- a/packages/core/src/nodes/NodeElement.tsx
+++ b/packages/core/src/nodes/NodeElement.tsx
@@ -1,24 +1,15 @@
-import React, { useMemo } from "react";
+import React from "react";
 import { NodeProvider } from "./NodeContext";
 import { RenderNodeToElement } from "../render/RenderNode";
 import { NodeId } from "../interfaces";
-import { NodeHandlers } from "./NodeHandlers";
-import { useEventHandler } from "../events";
 
 export type NodeElement = {
   id: NodeId;
 };
 
 export const NodeElement: React.FC<NodeElement> = React.memo(({ id }) => {
-  const handlers = useEventHandler();
-
-  const connectors = useMemo(
-    () => handlers.derive(NodeHandlers, id).connectors(),
-    [handlers, id]
-  );
-
   return (
-    <NodeProvider id={id} connectors={connectors}>
+    <NodeProvider id={id}>
       <RenderNodeToElement />
     </NodeProvider>
   );

--- a/packages/core/src/nodes/index.ts
+++ b/packages/core/src/nodes/index.ts
@@ -1,2 +1,3 @@
 export * from "./Canvas";
 export * from "./useNodeContext";
+export { NodeProvider } from "./NodeContext";

--- a/packages/core/src/nodes/useInternalNode.ts
+++ b/packages/core/src/nodes/useInternalNode.ts
@@ -1,4 +1,4 @@
-import { useContext, useMemo } from "react";
+import { useMemo } from "react";
 import { NodeProvider } from "./NodeContext";
 import { Node } from "../interfaces";
 import { useInternalEditor } from "../editor/useInternalEditor";

--- a/packages/examples/basic/pages/index.js
+++ b/packages/examples/basic/pages/index.js
@@ -24,22 +24,7 @@ export default function App() {
       <Typography style={{ margin: "20px 0" }} variant="h5" align="center">
         Basic Page Editor
       </Typography>
-      <Editor
-        normaliseNode={(state, actions, query) => {
-          return {
-            onAdd: (node) => {
-              // if ( node.data.displayName == "Button" )
-              //   state.nodes[node.id].data.props.size = "large"
-            },
-            onChildDelete: (node) => {
-              if (state.nodes[node.data.parent].data.type == Container) {
-                state.nodes[node.data.parent].data.props.background = "#333";
-              }
-            },
-          };
-        }}
-        resolver={{ Card, Button, Text, Container, CardTop, CardBottom }}
-      >
+      <Editor resolver={{ Card, Button, Text, Container, CardTop, CardBottom }}>
         <Topbar />
         <Grid container spacing={5} style={{ paddingTop: "10px" }}>
           <Grid item xs>

--- a/packages/examples/basic/pages/index.js
+++ b/packages/examples/basic/pages/index.js
@@ -24,7 +24,22 @@ export default function App() {
       <Typography style={{ margin: "20px 0" }} variant="h5" align="center">
         Basic Page Editor
       </Typography>
-      <Editor resolver={{ Card, Button, Text, Container, CardTop, CardBottom }}>
+      <Editor
+        normaliseNode={(state, actions, query) => {
+          return {
+            onAdd: (node) => {
+              // if ( node.data.displayName == "Button" )
+              //   state.nodes[node.id].data.props.size = "large"
+            },
+            onChildDelete: (node) => {
+              if (state.nodes[node.data.parent].data.type == Container) {
+                state.nodes[node.data.parent].data.props.background = "#333";
+              }
+            },
+          };
+        }}
+        resolver={{ Card, Button, Text, Container, CardTop, CardBottom }}
+      >
         <Topbar />
         <Grid container spacing={5} style={{ paddingTop: "10px" }}>
           <Grid item xs>

--- a/packages/utils/src/useMethods.ts
+++ b/packages/utils/src/useMethods.ts
@@ -99,10 +99,14 @@ export type PatchListenerAction<S, M extends MethodsOrOptions> = {
   patches: Patch[];
 };
 
-export type PatchListener<S, M extends MethodsOrOptions, Q> = (
+export type PatchListener<
+  S,
+  M extends MethodsOrOptions,
+  Q extends QueryMethods
+> = (
   draft: S,
   previousState: S,
-  actionPerformed: PatchListenerAction<S, M>,
+  actionPerformedWithPatches: PatchListenerAction<S, M>,
   query: QueryCallbacksFor<Q>
 ) => void;
 
@@ -341,9 +345,9 @@ class Watcher<S> {
   }
 
   notify() {
-    for (let i = 0; i < this.subscribers.length; i++) {
-      this.subscribers[i].collect();
-    }
+    this.subscribers.forEach((subscriber) => {
+      subscriber.collect();
+    });
   }
 }
 

--- a/packages/utils/src/useMethods.ts
+++ b/packages/utils/src/useMethods.ts
@@ -341,7 +341,6 @@ class Watcher<S> {
   }
 
   notify() {
-    // Give unsubscribing the priority. Any better way?
     for (let i = 0; i < this.subscribers.length; i++) {
       this.subscribers[i].collect();
     }

--- a/packages/utils/src/useMethods.ts
+++ b/packages/utils/src/useMethods.ts
@@ -105,7 +105,8 @@ export function useMethods<
 >(
   methodsOrOptions: MethodsOrOptions<S, R, QueryCallbacksFor<Q>>, // methods to manipulate the state
   initialState: any,
-  queryMethods: Q
+  queryMethods: Q,
+  patchListener: any
 ): SubscriberAndCallbacksFor<MethodsOrOptions<S, R>, Q>;
 
 export function useMethods<

--- a/packages/utils/src/useMethods.ts
+++ b/packages/utils/src/useMethods.ts
@@ -1,5 +1,5 @@
 // https://github.com/pelotom/use-methods
-import produce, { applyPatches, Patch, produceWithPatches } from "immer";
+import produce, { Patch, produceWithPatches } from "immer";
 import { useMemo, useEffect, useRef, useReducer, useCallback } from "react";
 import isEqualWith from "lodash.isequalwith";
 import { History } from "./History";


### PR DESCRIPTION
# New
Adds the ability to normalise the editor state when any `node.data` changes

Example:
```jsx
<Editor
    normaliseNodes={(state, previousState, actionPerformed) => {
        if ( Object.keys(state.nodes).length > Object.keys(previousState.nodes).length ) {
            // added a new node
        }

        Object.keys(state.nodes).forEach(id => {
            const node = state.nodes[id];
            // Change colors of all Buttons to primary
            if ( node.data.displayName == "Button" ) {
                node.data.props.color = "primary";
            }
        })

        console.log(actionPerformed.type) // add
    }}
>
```

# Testing
- [ ] Localhost
