### PR TITLE
fix: RTE undo/redo, throttle hover, ancestors infinite loop

### DIFF
--- a/packages/core/src/editor/Editor.tsx
+++ b/packages/core/src/editor/Editor.tsx
@@ -29,13 +29,15 @@ export const Editor: React.FC<Partial<Options>> = ({
 }) => {
   const context = useEditorStore(
     withDefaults(options),
-    (draft, previousState, actionPerformedWithPatches, query) => {
+    (_, previousState, actionPerformedWithPatches, query, normaliser) => {
       const { patches, ...actionPerformed } = actionPerformedWithPatches;
       for (let i = 0; i < patches.length; i++) {
         const { path } = patches[i];
-        if (path.length > 2 && path[0] == "nodes" && path[2] == "data") {
+        if (path.length > 2 && path[0] === "nodes" && path[2] === "data") {
           if (normaliseNodes) {
-            normaliseNodes(draft, previousState, actionPerformed, query);
+            normaliser((draft) => {
+              normaliseNodes(draft, previousState, actionPerformed, query);
+            });
           }
           break; // we exit the loop as soon as we find a change in node.data
         }

--- a/packages/core/src/editor/query.tsx
+++ b/packages/core/src/editor/query.tsx
@@ -283,7 +283,8 @@ export function QueryMethods(state: EditorState) {
               const targetDeepNodes = nodeQuery(targetNode.id).decendants();
               invariant(targetNode.data.parent, ERROR_MOVE_NONCANVAS_CHILD);
               invariant(
-                !targetDeepNodes.includes(newParentNode.id),
+                !targetDeepNodes.includes(newParentNode.id) &&
+                  newParentNode.id !== targetNode.id,
                 ERROR_MOVE_TO_DESCENDANT
               );
               invariant(

--- a/packages/core/src/editor/tests/actions.test.ts
+++ b/packages/core/src/editor/tests/actions.test.ts
@@ -181,11 +181,10 @@ describe("actions.setState", () => {
     const nodes = {
       "canvas-ROOT": {
         data: {
-          _childCanvas: undefined,
           custom: {},
           displayName: "Document",
-          hidden: undefined,
-          isCanvas: undefined,
+          hidden: false,
+          isCanvas: false,
           name: "Document",
           nodes: [],
           parent: undefined,

--- a/packages/core/src/events/EventHandlers.ts
+++ b/packages/core/src/events/EventHandlers.ts
@@ -3,6 +3,8 @@ import { NodeId, Node, Indicator, Tree } from "../interfaces";
 import { Handlers, ConnectorsForHandlers } from "@candulabs/craft-utils";
 import { debounce } from "debounce";
 import { EditorStore } from "../editor/store";
+import { Simulate } from "react-dom/test-utils";
+import drag = Simulate.drag;
 
 type DraggedElement = NodeId | Tree;
 
@@ -15,7 +17,7 @@ const event = ({
   handler: (e: MouseEvent, payload: any) => void;
   capture?: boolean;
 }) => (capture ? [name, handler, capture] : [name, handler]);
-const rapidDebounce = (f) => debounce(f, 1);
+const rapidDebounce = (f) => debounce(f, 100);
 
 /**
  * Specifies Editor-wide event handlers and connectors
@@ -46,9 +48,9 @@ export class EventHandlers extends Handlers<
         events: [
           event({
             name: "mouseover",
-            handler: rapidDebounce((_, id: NodeId) =>
-              this.store.actions.setNodeEvent("hovered", id)
-            ),
+            handler: rapidDebounce((e, id: NodeId) => {
+              this.store.actions.setNodeEvent("hovered", id);
+            }),
             capture: true,
           }),
         ],
@@ -73,9 +75,14 @@ export class EventHandlers extends Handlers<
                 return;
               }
 
-              const node = draggedElement.rootNodeId
-                ? draggedElement.nodes[draggedElement.rootNodeId]
-                : draggedElement;
+              let node: Node | NodeId = draggedElement as NodeId;
+
+              if (draggedElement["rootNodeId"]) {
+                node = (draggedElement as Tree).nodes[
+                  (draggedElement as Tree).rootNodeId
+                ];
+              }
+
               const { clientX: x, clientY: y } = e;
               const indicator = this.store.query.getDropPlaceholder(
                 node,

--- a/packages/core/src/events/EventHandlers.ts
+++ b/packages/core/src/events/EventHandlers.ts
@@ -3,8 +3,6 @@ import { NodeId, Node, Indicator, Tree } from "../interfaces";
 import { Handlers, ConnectorsForHandlers } from "@candulabs/craft-utils";
 import { debounce } from "debounce";
 import { EditorStore } from "../editor/store";
-import { Simulate } from "react-dom/test-utils";
-import drag = Simulate.drag;
 
 type DraggedElement = NodeId | Tree;
 
@@ -17,7 +15,7 @@ const event = ({
   handler: (e: MouseEvent, payload: any) => void;
   capture?: boolean;
 }) => (capture ? [name, handler, capture] : [name, handler]);
-const rapidDebounce = (f) => debounce(f, 100);
+const rapidDebounce = (f) => debounce(f, 10);
 
 /**
  * Specifies Editor-wide event handlers and connectors

--- a/packages/core/src/utils/deserializeNode.tsx
+++ b/packages/core/src/utils/deserializeNode.tsx
@@ -71,28 +71,31 @@ export const deserializeNode = (
 ): Omit<NodeData, "event"> => {
   const { type: Comp, props: Props, ...nodeData } = data;
 
+  const { type, name, props } = (deserializeComp(
+    data,
+    resolver
+  ) as unknown) as NodeData;
+
   const {
-    type,
-    name,
-    props,
     parent,
-    nodes,
-    _childCanvas,
-    isCanvas,
-    hidden,
     custom,
-  } = (deserializeComp(data, resolver) as unknown) as NodeData;
+    displayName,
+    isCanvas,
+    nodes,
+    hidden,
+    _childCanvas,
+  } = nodeData;
 
   return {
     type,
     name,
+    displayName: displayName || name,
     props,
     parent,
-    nodes,
-    _childCanvas,
-    isCanvas,
-    hidden,
-    custom,
-    ...nodeData,
+    custom: custom || {},
+    isCanvas: !!isCanvas,
+    hidden: !!hidden,
+    ...(_childCanvas ? { _childCanvas } : {}),
+    ...(nodes ? { nodes } : {}),
   };
 };


### PR DESCRIPTION
# New

This PR introduces a couple of fix:
- Undo/redo (Currently, changes made in normalising function does not get recorded)
- Throttles mouseover event
- Fixes the `Maximum call stack size exceeded` that occurs when you try to drag a RTE node into itself 

# Testing
<!-- Please select all the testing methods that apply to this pr -->
- [X] Localhost

