### PR TITLE
fix: undo/redo event indicators

### DIFF
--- a/packages/core/src/editor/store.tsx
+++ b/packages/core/src/editor/store.tsx
@@ -17,15 +17,16 @@ export const ActionMethodsWithConfig = {
   ] as const,
   normalizeHistory: (state) => {
     /**
-     * On every undo/redo, we want to reset these values
-     * because their changes are not tracked by the history manager
+     * On every undo/redo, we remove events pointing to deleted Nodes
      */
-    state.events = {
-      selected: null,
-      dragged: null,
-      hovered: null,
-      indicator: null,
-    };
+
+    Object.keys(state.events).forEach((eventName) => {
+      const nodeId = state.events[eventName];
+
+      if (!!nodeId && !state.nodes[nodeId]) {
+        state.events[eventName] = false;
+      }
+    });
   },
 };
 

--- a/packages/utils/src/useMethods.ts
+++ b/packages/utils/src/useMethods.ts
@@ -177,21 +177,11 @@ export function useMethods<
           (draft: S) => {
             switch (action.type) {
               case "undo": {
-                if (history.canUndo()) {
-                  if (normalizeHistory) {
-                    normalizeHistory(draft);
-                  }
-                  return history.undo(draft);
-                }
+                history.undo(draft);
                 break;
               }
               case "redo": {
-                if (history.canRedo()) {
-                  if (normalizeHistory) {
-                    normalizeHistory(draft);
-                  }
-                  return history.redo(draft);
-                }
+                history.redo(draft);
                 break;
               }
 
@@ -226,6 +216,9 @@ export function useMethods<
           );
         }
 
+        if (["undo", "redo"].includes(action.type as any) && normalizeHistory) {
+          finalState = produce(finalState, normalizeHistory);
+        }
         if (
           ![
             ...ignoreHistoryForActions,


### PR DESCRIPTION
# New
<!-- Provide a description of the changes you’ve made in this pr -->

- Currently on every undo/redo we reset the events by reseting the values in `state.events`. However, the event values in `state.nodes[node].events` are not removed, this causes the event indicators to remain

# Testing
<!-- Please select all the testing methods that apply to this pr -->

- [ ] Unit
- [ ] Integration
- [ ] Localhost


# Screenshots
<!-- If you have made client facing changes please provide screenshots -->

