### PR TITLE
feat: finalise History API

### DIFF
--- a/packages/core/src/editor/actions.ts
+++ b/packages/core/src/editor/actions.ts
@@ -22,7 +22,6 @@ import { QueryMethods } from './query';
 import { fromEntries } from '../utils/fromEntries';
 import { updateEventsNode } from '../utils/updateEventsNode';
 import invariant from 'tiny-invariant';
-import { editorInitialState } from './store';
 
 export const Actions = (
   state: EditorState,

--- a/packages/core/src/editor/store.tsx
+++ b/packages/core/src/editor/store.tsx
@@ -22,6 +22,7 @@ export const ActionMethodsWithConfig = {
   ignoreHistoryForActions: [
     'setDOM',
     'setNodeEvent',
+    'clearEvents',
     'setOptions',
     'setIndicator',
   ] as const,

--- a/packages/core/src/hooks/tests/useEditor.test.tsx
+++ b/packages/core/src/hooks/tests/useEditor.test.tsx
@@ -40,7 +40,11 @@ describe('useEditor', () => {
   it('should return the correct editor', () => {
     expect(editor).toEqual(
       expect.objectContaining({
-        actions: { ...otherActions, selectNode: expect.any(Function) },
+        actions: {
+          ...otherActions,
+          history: expect.any(Object),
+          selectNode: expect.any(Function),
+        },
         connectors: state.connectors,
         query: otherQueries,
         aRandomValue: state.aRandomValue,

--- a/packages/core/src/render/Frame.tsx
+++ b/packages/core/src/render/Frame.tsx
@@ -32,7 +32,7 @@ export const Frame: React.FC<Frame> = ({ children, json, data }) => {
     const { initialChildren, initialData } = initialState.current;
 
     if (initialData) {
-      actions.runWithoutHistory.deserialize(initialData);
+      actions.history.ignore().deserialize(initialData);
     } else if (initialChildren) {
       const rootNode = React.Children.only(
         initialChildren
@@ -45,7 +45,7 @@ export const Frame: React.FC<Frame> = ({ children, json, data }) => {
         return node;
       });
 
-      actions.runWithoutHistory.addNodeTree(node);
+      actions.history.ignore().addNodeTree(node);
     }
 
     setRender(<NodeElement id={ROOT_NODE} />);

--- a/packages/core/src/render/tests/Frame.test.tsx
+++ b/packages/core/src/render/tests/Frame.test.tsx
@@ -13,12 +13,20 @@ const mockEditor = useInternalEditor as jest.Mock<any>;
 
 describe('<Frame />', () => {
   const data = {};
+  const addNodeTree = jest.fn();
+  const deserialize = jest.fn();
+
   let actions;
   let query;
 
   beforeEach(() => {
     actions = {
-      runWithoutHistory: { addNodeTree: jest.fn(), deserialize: jest.fn() },
+      history: {
+        ignore: jest.fn().mockImplementation(() => ({
+          addNodeTree,
+          deserialize,
+        })),
+      },
     };
     query = { createNode: jest.fn(), parseTreeFromReactNode: jest.fn() };
     mockEditor.mockImplementation(() => ({ actions, query }));
@@ -29,7 +37,7 @@ describe('<Frame />', () => {
       mount(<Frame data={data} />);
     });
     it('should deserialize the nodes', () => {
-      expect(actions.runWithoutHistory.deserialize).toHaveBeenCalledWith(data);
+      expect(deserialize).toHaveBeenCalledWith(data);
     });
   });
 });

--- a/packages/utils/src/History.ts
+++ b/packages/utils/src/History.ts
@@ -7,6 +7,13 @@ type Timeline = Array<{
   timestamp: number;
 }>;
 
+export const HISTORY_ACTIONS = {
+  UNDO: 'UNDO',
+  REDO: 'REDO',
+  THROTTLE: 'THROTTLE',
+  IGNORE: 'IGNORE',
+};
+
 export class History {
   timeline: Timeline = [];
   pointer = -1;

--- a/packages/utils/src/utilityTypes.ts
+++ b/packages/utils/src/utilityTypes.ts
@@ -1,2 +1,5 @@
 export type Overwrite<T, U> = Pick<T, Exclude<keyof T, keyof U>> & U;
 export type Delete<T, U> = Pick<T, Exclude<keyof T, U>>;
+export type OverwriteFnReturnType<F extends (...args: any) => void, R> = (
+  ...args: Parameters<F>
+) => Delete<ReturnType<F>, R>;


### PR DESCRIPTION
# New
<!-- Provide a description of the changes you’ve made in this pr -->

- Improve History API to merge into main repo
- Renamed actions
  - `undo()` => `history.undo()`
  - `redo()` => `history.redo()`
  - `runWithoutHistory()` => `history.ignore()`
  - `throttleHistory()` => `history.throttle()`
- Renamed query
  - `canUndo()` => `history.canUndo()`
  - `canRedo()` => `history.canRedo()`

# Testing
<!-- Please select all the testing methods that apply to this pr -->

- [X] Localhost


# Screenshots
<!-- If you have made client facing changes please provide screenshots -->

